### PR TITLE
update browser-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "accepts": "1.1.1",
     "bcrypt": "0.7.8",
     "body-parser": "1.3.0",
+    "browser-sync": "^2.7.1",
     "campaign": "1.4.3",
     "campaign-jadum": "1.1.0",
     "cheerio": "0.17.0",


### PR DESCRIPTION
update browser-sync to prevent this error

04:43 - info: app listening on port 3000

util.js:556
  ctor.prototype = Object.create(superCtor.prototype, {
                                          ^
TypeError: Cannot read property 'prototype' of undefined
    at Object.exports.inherits (util.js:556:43)
    at Object.<anonymous> (../contenidos/node_modules/browser-sync/node_modules/http-proxy/lib/http-proxy/index.js:106:17)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (../contenidos/node_modules/browser-sync/node_modules/http-proxy/lib/http-proxy.js:4:17)
    at Module._compile (module.js:456:26)